### PR TITLE
Don't apply polyfill when functions available natively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4" # To ensure compatibility with natively available functions
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Provides user-land PHP polyfills for the [`mb_ucfirst` and `mb_ucfirst` functions added in PHP 8.4](https://php.watch/versions/8.4/mb_ucfirst-mb_ucfirst).
 
-Requires PHP 8,1, 8.2 or PHP 8.3 with `mbstring` extension. Not supported on PHP 8.4 because these functions are natively implemented in PHP 8.4.
+Requires PHP 8.1 or newer with `mbstring` extension.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,6 @@
     "require-dev": {
         "phpunit/phpunit": "^10.5.11"
     },
-    "conflict": {
-        "php": "^8.4"
-    },
     "license": "MIT",
     "autoload": {
         "files": [

--- a/src/mb_ucfirst_lcfirst.php
+++ b/src/mb_ucfirst_lcfirst.php
@@ -1,21 +1,25 @@
 <?php
 
-/**
- * Make a string's first character uppercase multi-byte safely.
- */
-function mb_ucfirst(string $string, ?string $encoding = null): string {
-    $firstChar = mb_substr($string, 0, 1, $encoding);
-    $firstChar = mb_convert_case($firstChar, MB_CASE_TITLE, $encoding);
+if (!function_exists('mb_ucfirst')) {
+    /**
+     * Make a string's first character uppercase multi-byte safely.
+     */
+    function mb_ucfirst(string $string, ?string $encoding = null): string {
+        $firstChar = mb_substr($string, 0, 1, $encoding);
+        $firstChar = mb_convert_case($firstChar, MB_CASE_TITLE, $encoding);
 
-    return $firstChar . mb_substr($string, 1, null, $encoding);
+        return $firstChar . mb_substr($string, 1, null, $encoding);
+    }
 }
 
-/**
- * Make a string's first character lowercase multi-byte safely.
- */
-function mb_lcfirst(string $string, ?string $encoding = null): string {
-    $firstChar = mb_substr($string, 0, 1, $encoding);
-    $firstChar = mb_convert_case($firstChar, MB_CASE_LOWER, $encoding);
+if (!function_exists('mb_lcfirst')) {
+    /**
+     * Make a string's first character lowercase multi-byte safely.
+     */
+    function mb_lcfirst(string $string, ?string $encoding = null): string {
+        $firstChar = mb_substr($string, 0, 1, $encoding);
+        $firstChar = mb_convert_case($firstChar, MB_CASE_LOWER, $encoding);
 
-    return $firstChar . mb_substr($string, 1, null, $encoding);
+        return $firstChar . mb_substr($string, 1, null, $encoding);
+    }
 }


### PR DESCRIPTION
This will not only provide a smoother transition to PHP 8.4, but will also allow PHPStan to work properly on PHP 8.3 and older.